### PR TITLE
Fix: valkey-server loglevel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   valkey:
     image: valkey/valkey:8-alpine
-    command: valkey-server --loglevel debug --save 60 1
+    command: valkey-server --loglevel warning --save 60 1
     restart: unless-stopped
     logging:
       driver: "json-file"


### PR DESCRIPTION
Encountered this
```
valkey-1  | *** FATAL CONFIG FILE ERROR (Version 8.1.4) ***
valkey-1  | Reading the configuration file, at line 2
valkey-1  | >>> 'loglevel "error"'
valkey-1  | argument(s) must be one of the following: debug, verbose, notice, warning, nothing
```
Based on example config file [[1]](https://raw.githubusercontent.com/valkey-io/valkey/8.1/valkey.conf) decided to go with debug